### PR TITLE
Add carousel hero and calendar links

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,4 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     loadComponent('header.html', 'header-placeholder');
     loadComponent('footer.html', 'footer-placeholder');
+    const memberScript = document.createElement('script');
+    memberScript.src = 'membership.js';
+    document.body.appendChild(memberScript);
 });

--- a/dark.html
+++ b/dark.html
@@ -39,35 +39,7 @@
     <div id="fb-root"></div>
     <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v18.0" nonce="aBcDeFg"></script>
 
-    <header class="bg-gray-800 shadow-md sticky top-0 z-50">
-        <nav class="container mx-auto px-6 py-3 flex justify-between items-center">
-            <div class="flex items-center">
-                <a href="#" class="flex items-center">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/918D5B2F-EEA0-4A9E-AC15-88359C704F97.png" alt="Kokomo Art Association Logo" class="h-12 w-auto" onerror="this.onerror=null;this.src='https://placehold.co/150x50/000000/FFFFFF?text=KAA+Logo';">
-                    <span class="hidden md:inline ml-4 text-black text-lg font-semibold">Kokomo Art Association</span>
-                </a>
-            </div>
-            <div class="hidden md:flex items-center space-x-6">
-                <a href="#about" class="text-gray-300 hover:text-teal-600 font-semibold">About</a>
-                <a href="#events" class="text-gray-300 hover:text-teal-600 font-semibold">Events</a>
-                <a href="#artists" class="text-gray-300 hover:text-teal-600 font-semibold">Artists</a>
-                <a href="#locations" class="text-gray-300 hover:text-teal-600 font-semibold">Locations</a>
-                <a href="#membership" class="text-gray-300 hover:text-teal-600 font-semibold">Membership</a>
-                <a href="#donate" class="text-gray-300 hover:text-teal-600 font-semibold">Donate</a>
-            </div>
-            <button id="mobile-menu-button" class="md:hidden flex items-center">
-                <i class="fas fa-bars text-gray-300 text-2xl"></i>
-            </button>
-        </nav>
-        <div id="mobile-menu" class="hidden md:hidden px-6 pb-4 bg-gray-800 border-t">
-             <a href="#about" class="block py-2 text-gray-300 hover:text-teal-600">About</a>
-             <a href="#events" class="block py-2 text-gray-300 hover:text-teal-600">Events</a>
-             <a href="#artists" class="block py-2 text-gray-300 hover:text-teal-600">Artists</a>
-             <a href="#locations" class="block py-2 text-gray-300 hover:text-teal-600">Locations</a>
-             <a href="#membership" class="block py-2 text-gray-300 hover:text-teal-600">Membership</a>
-             <a href="#donate" class="block py-2 text-gray-300 hover:text-teal-600">Donate</a>
-        </div>
-    </header>
+    <div id="header-placeholder"></div>
 
     <main>
         <section class="w-full bg-gray-800 flex justify-center" style="max-height: 40vh;">
@@ -230,33 +202,8 @@
                 </div>
             </section>
         </div>
+    <div id="footer-placeholder"></div>
     </main>
-
-    <footer id="footer" class="bg-gray-800 text-gray-100 border-t">
-        <div class="container mx-auto px-6 py-12">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-                <div class="md:col-span-2"><h4 class="font-bold text-lg mb-4 text-gray-100">About KAA</h4><p class="text-gray-300">The Kokomo Art Association was organized in 1926. Bylaws and a constitution were established in 1962, and not-for-profit status was attained in 1981. We are dedicated to promoting the arts and supporting local artists in our community.</p></div>
-                <div><h4 class="font-bold text-lg mb-4 text-gray-100">Quick Links</h4><ul><li class="mb-2"><a href="#events" class="text-gray-300 hover:text-teal-600">Events</a></li><li class="mb-2"><a href="#classes" class="text-gray-300 hover:text-teal-600">Classes</a></li><li class="mb-2"><a href="#artists" class="text-gray-300 hover:text-teal-600">Artists</a></li><li class="mb-2"><a href="#membership" class="text-gray-300 hover:text-teal-600">Membership</a></li><li class="mb-2"><a href="#donate" class="text-gray-300 hover:text-teal-600">Donate</a></li></ul></div>
-                <div><h4 class="font-bold text-lg mb-4 text-gray-100">Join Our Newsletter</h4><form onsubmit="return false;"><div class="flex"><input type="email" class="w-full rounded-l-md px-3 py-2 border border-gray-300 text-gray-100" placeholder="your.email@example.com"><button type="submit" class="bg-teal-600 text-white px-4 py-2 rounded-r-md hover:bg-teal-700">&rarr;</button></div></form><div class="flex space-x-4 mt-4"><a href="https://www.facebook.com/KokomoArtAssociation/?fref=ts" target="_blank" rel="noopener noreferrer" aria-label="Facebook" class="text-2xl text-gray-400 hover:text-teal-600"><i class="fab fa-facebook-square"></i></a><a href="https://www.instagram.com/kokomoartassociation/" target="_blank" rel="noopener noreferrer" aria-label="Instagram" class="text-2xl text-gray-400 hover:text-teal-600"><i class="fab fa-instagram-square"></i></a></div></div>
-            </div>
-            <div class="border-t border-gray-200 mt-12 pt-8">
-                <h4 class="font-bold text-lg mb-6 text-center text-gray-200">Our Valued Sponsors</h4>
-                <div class="flex flex-wrap justify-center items-center gap-8">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
-                </div>
-            </div>
-            <div class="border-t border-gray-200 mt-8 pt-6 text-center text-gray-300"><p>&copy; <span id="year"></span> Kokomo Art Association. All Rights Reserved.</p></div>
-        </div>
-    </footer>
-    
-    <div id="modal-placeholder"></div>
-
     <script>
     document.addEventListener('DOMContentLoaded', () => {
         const artistData = {
@@ -451,10 +398,7 @@
             }
         };
         
-        updateSigns();
-        setInterval(updateSigns, 60000);
-        renderCalendar();
-    });
     </script>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/donate.html
+++ b/donate.html
@@ -57,38 +57,7 @@
     <div id="fb-root"></div>
     <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v18.0" nonce="aBcDeFg"></script>
 
-    <!-- Header and Navigation -->
-    <header class="bg-white shadow-md sticky top-0 z-50">
-        <nav class="container mx-auto px-6 py-3 flex justify-between items-center">
-            <div class="flex items-center">
-                <a href="index.html" class="flex items-center">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/918D5B2F-EEA0-4A9E-AC15-88359C704F97.png" alt="Kokomo Art Association Logo" class="h-12 w-auto" onerror="this.onerror=null;this.src='https://placehold.co/150x50/000000/FFFFFF?text=KAA+Logo';">
-                </a>
-                <span class="hidden md:inline ml-4 text-black text-lg font-semibold">Kokomo Art Association</span>
-            </div>
-            <div class="hidden md:flex items-center space-x-6">
-                <a href="about.html" class="text-gray-600 hover:text-teal-600 font-semibold">About</a>
-                <a href="events.html" class="text-gray-600 hover:text-teal-600 font-semibold">Events</a>
-                <a href="locations.html" class="text-gray-600 hover:text-teal-600 font-semibold">Locations</a>
-                 <a href="community_hub.html" class="text-gray-600 hover:text-teal-600 font-semibold">Community Hub</a>
-                <a href="get_involved.html" class="text-gray-600 hover:text-teal-600 font-semibold">Get Involved</a>
-                <a href="donate.html" class="text-gray-600 hover:text-teal-600 font-semibold">Donate</a>
-            </div>
-            <button id="mobile-menu-button" class="md:hidden flex items-center">
-                <i class="fas fa-bars text-gray-600 text-2xl"></i>
-            </button>
-        </div>
-        </nav>
-        <!-- Mobile Menu -->
-        <div id="mobile-menu" class="hidden md:hidden px-6 pb-4 bg-white border-t">
-            <a href="about.html" class="block py-2 text-gray-600 hover:text-teal-600">About</a>
-            <a href="events.html" class="block py-2 text-gray-600 hover:text-teal-600">Events</a>
-            <a href="locations.html" class="block py-2 text-gray-600 hover:text-teal-600">Locations</a>
-            <a href="community_hub.html" class="block py-2 text-gray-600 hover:text-teal-600">Community Hub</a>
-            <a href="get_involved.html" class="block py-2 text-gray-600 hover:text-teal-600">Get Involved</a>
-            <a href="donate.html" class="block py-2 text-gray-600 hover:text-teal-600">Donate</a>
-        </div>
-    </header>
+    <div id="header-placeholder"></div>
 
     <main>
         <!-- Hero Section - Can be kept or modified for the donate page -->
@@ -122,27 +91,7 @@
 
     </main>
 
-    <footer id="footer" class="bg-white text-gray-800 border-t">
-        <div class="container mx-auto px-6 py-12">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div class="md:col-span-2"><h4 class="font-bold text-lg mb-4 text-gray-900">About KAA</h4><p class="text-gray-600">The Kokomo Art Association was organized in 1926. Bylaws and a constitution were established in 1962, and not-for-profit status was attained in 1981. We are dedicated to promoting the arts and supporting local artists in our community.</p></div>
-                <div><h4 class="font-bold text-lg mb-4 text-gray-900">Join Our Newsletter</h4><form onsubmit="return false;"><div class="flex"><input type="email" class="w-full rounded-l-md px-3 py-2 border border-gray-300 text-gray-800" placeholder="your.email@example.com"><button type="submit" class="bg-teal-600 text-white px-4 py-2 rounded-r-md hover:bg-teal-700">→</button></div></form><div class="flex space-x-4 mt-4"><a href="https://www.facebook.com/KokomoArtAssociation/?fref=ts" target="_blank" rel="noopener noreferrer" aria-label="Facebook" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-facebook-square"></i></a><a href="https://www.instagram.com/kokomoartassociation/" target="_blank" rel="noopener noreferrer" aria-label="Instagram" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-instagram-square"></i></a></div></div>
-            </div>
-            <div class="border-t border-gray-200 mt-12 pt-8">
-                <h4 class="font-bold text-lg mb-6 text-center text-gray-700">Our Valued Sponsors</h4>
-                <div class="flex flex-wrap justify-center items-center gap-8">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
-                </div>
-            </div>
-            <div class="border-t border-gray-200 mt-8 pt-6 text-center text-gray-600"><p>© <span id="year"></span> Kokomo Art Association. All Rights Reserved.</p></div>
-        </div>
-    </footer>
+    <div id="footer-placeholder"></div>
 
     <!-- Modal placeholder -->
     <div id="modal-placeholder"></div>
@@ -369,4 +318,15 @@
         });
 
         // --- EVENT LISTENERS ---
-        document.body.addEventListener('click', function(event)
+        document.body.addEventListener('click', (event) => {
+            if (event.target.classList.contains('modal-overlay') || event.target.id === 'modal-close-btn') {
+                document.getElementById('modal-overlay')?.classList.remove('visible');
+            }
+        });
+        });
+    });
+    </script>
+    <script src="app.js"></script>
+    <script src="membership.js"></script>
+</body>
+</html>

--- a/events.html
+++ b/events.html
@@ -57,39 +57,7 @@
     <div id="fb-root"></div>
     <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v18.0" nonce="aBcDeFg"></script>
 
-    <!-- Header and Navigation -->
-    <header class="bg-white shadow-md sticky top-0 z-50">
-        <nav class="container mx-auto px-6 py-3 flex justify-between items-center">
-            <div class="flex items-center flex-shrink-0">
-                <a href="index.html" class="flex items-center">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/918D5B2F-EEA0-4A9E-AC15-88359C704F97.png" alt="Kokomo Art Association Logo" class="h-12 w-auto" onerror="this.onerror=null;this.src='https://placehold.co/150x50/000000/FFFFFF?text=KAA+Logo';">
-                    <span class="hidden md:inline ml-4 text-black text-lg font-semibold">Kokomo Art Association</span>
-                </a>
-            </div>
-            <div class="hidden md:flex items-center space-x-6">
-                <a href="about.html" class="text-gray-600 hover:text-teal-600 font-semibold">About</a>
-                <a href="events.html" class="text-teal-600 font-semibold">Events</a>
-                <a href="locations.html" class="text-gray-600 hover:text-teal-600 font-semibold">Locations</a>
-                <a href="get_involved.html" class="text-gray-600 hover:text-teal-600 font-semibold">Get Involved</a>
-                 <a href="community_hub.html" class="text-gray-600 hover:text-teal-600 font-semibold">Community Hub</a>
-                <a href="donate.html" class="text-gray-600 hover:text-teal-600 font-semibold">Donate</a>
-                 <a href="index.html" class="text-gray-600 hover:text-teal-600 font-semibold">Home</a>
-            </div>
-            <button id="mobile-menu-button" class="md:hidden flex items-center">
-                <i class="fas fa-bars text-gray-600 text-2xl"></i>
-            </button>
-        </nav>
-        <!-- Mobile Menu -->
-        <div id="mobile-menu" class="hidden md:hidden px-6 pt-2 pb-4 bg-white border-t space-y-2">
-             <a href="about.html" class="block py-2 text-gray-600 hover:text-teal-600">About</a>
-             <a href="events.html" class="block py-2 text-gray-600 hover:text-teal-600">Events</a>
-             <a href="locations.html" class="block py-2 text-gray-600 hover:text-teal-600">Locations</a>
-             <a href="get_involved.html" class="block py-2 text-gray-600 hover:text-teal-600">Get Involved</a>
-              <a href="community_hub.html" class="block py-2 text-gray-600 hover:text-teal-600">Community Hub</a>
-             <a href="donate.html" class="block py-2 text-gray-600 hover:text-teal-600">Donate</a>
-        </div>
-
-    </header>
+    <div id="header-placeholder"></div>
 
     <main>
         <!-- Hero Section (Optional - can be removed or simplified for inner pages) -->
@@ -117,30 +85,7 @@
 
     </main>
 
-    <footer id="footer" class="bg-white text-gray-800 border-t">
-        <div class="container mx-auto px-6 py-12">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div class="md:col-span-2"><h4 class="font-bold text-lg mb-4 text-gray-900">About KAA</h4><p class="text-gray-600">The Kokomo Art Association was organized in 1926. Bylaws and a constitution were established in 1962, and not-for-profit status was attained in 1981. We are dedicated to promoting the arts and supporting local artists in our community.</p></div>
-                <div><h4 class="font-bold text-lg mb-4 text-gray-900">Join Our Newsletter</h4><form onsubmit="return false;"><div class="flex"><input type="email" class="w-full rounded-l-md px-3 py-2 border border-gray-300 text-gray-800" placeholder="your.email@example.com"><button type="submit" class="bg-teal-600 text-white px-4 py-2 rounded-r-md hover:bg-teal-700">→</button></div></form><div class="flex space-x-4 mt-4"><a href="https://www.facebook.com/KokomoArtAssociation/?fref=ts" target="_blank" rel="noopener noreferrer" aria-label="Facebook" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-facebook-square"></i></a><a href="https://www.instagram.com/kokomoartassociation/" target="_blank" rel="noopener noreferrer" aria-label="Instagram" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-instagram-square"></i></a></div></div>
-            </div>
-            <div class="border-t border-gray-200 mt-12 pt-8">
-                <h4 class="font-bold text-lg mb-6 text-center text-gray-700">Our Valued Sponsors</h4>
-                <div class="flex flex-wrap justify-center items-center gap-8">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
-                </div>
-            </div>
-            <div class="border-t border-gray-200 mt-8 pt-6 text-center text-gray-600"><p>© <span id="year"></span> Kokomo Art Association. All Rights Reserved.</p></div>
-        </div>
-    </footer>
-
-    <!-- Modal placeholder -->
-    <div id="modal-placeholder"></div>
+    <div id="footer-placeholder"></div>
 
     <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -162,7 +107,20 @@
             '2025-3-15': [ { title: 'Junk Journal Workshop', time: '12:00 PM - 4:00 PM', description: 'Create a handmade journal from recycled and repurposed materials with talented artist Vivian Bennett.', cost: '$62.50 (all materials included)' } ],
             '2025-7-13': [ { title: 'Reception for Brandon C. Bass', time: '12:00 PM - 3:00 PM', description: 'Join us for a reception celebrating our July guest artist, Brandon C. Bass. Light refreshments will be served.', cost: 'Free to attend' } ]
         };
-         const classes = [
+        const generateCalendarLinks = (key, ev) => {
+            const [y,m,d] = key.split('-').map(Number);
+            const [startStr,endStr] = ev.time.split(' - ');
+            const parse = s => { const [t,amp]=s.split(' '); let [hh,mm]=t.split(':').map(Number); if(amp==='PM' && hh<12) hh+=12; if(amp==='AM' && hh===12) hh=0; return {hh,mm}; };
+            const st=new Date(y,m-1,d, ...Object.values(parse(startStr)));
+            const en=new Date(y,m-1,d, ...Object.values(parse(endStr)));
+            const pad=x=>String(x).padStart(2,'0');
+            const fmt=dt=>`${dt.getFullYear()}${pad(dt.getMonth()+1)}${pad(dt.getDate())}T${pad(dt.getHours())}${pad(dt.getMinutes())}00`;
+            const gLink=`https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(ev.title)}&dates=${fmt(st)}/${fmt(en)}&details=${encodeURIComponent(ev.description)}`;
+            const ics=`BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:${ev.title}\nDESCRIPTION:${ev.description}\nDTSTART:${fmt(st)}\nDTEND:${fmt(en)}\nEND:VEVENT\nEND:VCALENDAR`;
+            const icsLink=`data:text/calendar;charset=utf8,${encodeURIComponent(ics)}`;
+            return `<div class="mt-4 space-y-2"><a href="${gLink}" target="_blank" class="text-teal-600 hover:text-teal-800 font-semibold">Add to Google Calendar</a><br><a href="${icsLink}" download="event.ics" class="text-teal-600 hover:text-teal-800 font-semibold">Add to Outlook/Apple Calendar</a></div>`;
+        };
+        const classes = [
             { title: 'Watercolor Techniques', instructor: 'Dixie Ben-net', description: 'Explore the transparent and luminous qualities of watercolor. This class is for beginners and those with some experience.', schedule: 'Tuesdays, 6:00 PM - 8:00 PM', price: '$120 for 4 weeks' },
             { title: 'Pastels', instructor: 'Avon Waters', description: 'Learn to create vibrant and expressive pastel paintings. We will cover composition, color theory, and layering techniques.', schedule: 'Wednesdays, 1:00 PM - 3:00 PM', price: '$130 for 4 weeks' },
             { title: 'Photography', instructor: 'Bob Dawson', description: 'This class covers the fundamentals of digital photography, including camera settings, lighting, and composition.', schedule: 'Thursdays, 6:00 PM - 8:00 PM', price: '$150 for 6 weeks' },
@@ -290,7 +248,8 @@
                     dayEl.appendChild(dot);
                     dayEl.addEventListener('click', () => {
                         const event = events[eventKey][0];
-                        const content = `<h2 class="text-2xl font-bold mb-2">${event.title}</h2><p class="text-gray-500 font-semibold mb-4">${event.time}</p><p class="text-gray-700 mb-4">${event.description}</p><p class="font-bold mb-6">${event.cost}</p><button class="event-form-trigger-modal w-full bg-teal-600 text-white py-2 px-4 rounded-md hover:bg-teal-700">Register Now</button>`;
+                        const links = generateCalendarLinks(eventKey, event);
+                        const content = `<h2 class="text-2xl font-bold mb-2">${event.title}</h2><p class="text-gray-500 font-semibold mb-4">${event.time}</p><p class="text-gray-700 mb-4">${event.description}</p><p class="font-bold mb-6">${event.cost}</p>${links}<button class="event-form-trigger-modal w-full bg-teal-600 text-white py-2 px-4 rounded-md hover:bg-teal-700 mt-4">Register Now</button>`;
                         createModal(content);
                     });
                 }
@@ -342,5 +301,6 @@
         renderCalendar();
     });
     </script>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/footer.html
+++ b/footer.html
@@ -6,7 +6,7 @@
             </div>
             <div class="border-t border-gray-200 mt-12 pt-8">
                 <h4 class="font-bold text-lg mb-6 text-center text-gray-700">Our Valued Sponsors</h4>
- <div class="flex flex-wrap justify-center items-center gap-x-8 gap-y-4">
+ <div class="flex flex-wrap md:flex-nowrap justify-center items-center gap-x-8 gap-y-4">
                     <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
                     <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
                     <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">

--- a/get_involved.html
+++ b/get_involved.html
@@ -24,39 +24,7 @@
 </head>
 <body class="bg-gray-50 text-gray-800">
 
-    <!-- Header and Navigation -->
-    <header class="bg-white shadow-md sticky top-0 z-50">
-        <nav class="container mx-auto px-6 py-3 flex justify-between items-center">
-            <div class="flex items-center">
-                <a href="index.html" class="flex items-center">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/918D5B2F-EEA0-4A9E-AC15-88359C704F97.png" alt="Kokomo Art Association Logo" class="h-12 w-auto" onerror="this.onerror=null;this.src='https://placehold.co/150x50/000000/FFFFFF?text=KAA+Logo';">
-                    <span class="hidden md:inline ml-4 text-black text-lg font-semibold">Kokomo Art Association</span>
-                </a>
-            </div>
-             <div class="hidden md:flex items-center space-x-6">
-                <a href="index.html" class="text-gray-600 hover:text-teal-600 font-semibold">Home</a>
-                <a href="about.html" class="text-gray-600 hover:text-teal-600 font-semibold">About</a>
-                <a href="events.html" class="text-gray-600 hover:text-teal-600 font-semibold">Events</a>
-                <a href="locations.html" class="text-gray-600 hover:text-teal-600 font-semibold">Locations</a>
-                 <a href="community_hub.html" class="text-gray-600 hover:text-teal-600 font-semibold">Community Hub</a>
-                <a href="get_involved.html" class="text-teal-600 hover:text-teal-600 font-semibold">Get Involved</a>
-                <a href="donate.html" class="text-gray-600 hover:text-teal-600 font-semibold">Donate</a>
-            </div>
-            <button id="mobile-menu-button" class="md:hidden flex items-center">
-                <i class="fas fa-bars text-gray-600 text-2xl"></i>
-            </button>
-        </nav>
-        <!-- Mobile Menu -->
-        <div id="mobile-menu" class="hidden md:hidden px-6 pb-4 bg-white border-t">
-             <a href="index.html" class="block py-2 text-gray-600 hover:text-teal-600">Home</a>
-             <a href="about.html" class="block py-2 text-gray-600 hover:text-teal-600">About</a>
-             <a href="events.html" class="block py-2 text-gray-600 hover:text-teal-600">Events</a>
-             <a href="locations.html" class="block py-2 text-gray-600 hover:text-teal-600">Locations</a>
-              <a href="community_hub.html" class="block py-2 text-gray-600 hover:text-teal-600">Community Hub</a>
-             <a href="get_involved.html" class="block py-2 text-teal-600 hover:text-teal-600">Get Involved</a>
-             <a href="donate.html" class="block py-2 text-gray-600 hover:text-teal-600">Donate</a>
-        </div>
-    </header>
+    <div id="header-placeholder"></div>
 
     <main>
         <section id="get-involved" class="py-12 md:py-20">
@@ -96,27 +64,7 @@
             </div>
         </main>
 
-    <footer id="footer" class="bg-white text-gray-800 border-t">
-        <div class="container mx-auto px-6 py-12">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div class="md:col-span-2"><h4 class="font-bold text-lg mb-4 text-gray-900">About KAA</h4><p class="text-gray-600">The Kokomo Art Association was organized in 1926. Bylaws and a constitution were established in 1962, and not-for-profit status was attained in 1981. We are dedicated to promoting the arts and supporting local artists in our community.</p></div>
-                <div><h4 class="font-bold text-lg mb-4 text-gray-900">Join Our Newsletter</h4><form onsubmit="return false;"><div class="flex"><input type="email" class="w-full rounded-l-md px-3 py-2 border border-gray-300 text-gray-800" placeholder="your.email@example.com"><button type="submit" class="bg-teal-600 text-white px-4 py-2 rounded-r-md hover:bg-teal-700">→</button></div></form><div class="flex space-x-4 mt-4"><a href="https://www.facebook.com/KokomoArtAssociation/?fref=ts" target="_blank" rel="noopener noreferrer" aria-label="Facebook" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-facebook-square"></i></a><a href="https://www.instagram.com/kokomoartassociation/" target="_blank" rel="noopener noreferrer" aria-label="Instagram" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-instagram-square"></i></a></div></div>
-            </div>
-            <div class="border-t border-gray-200 mt-12 pt-8">
-                <h4 class="font-bold text-lg mb-6 text-center text-gray-700">Our Valued Sponsors</h4>
-                <div class="flex flex-wrap justify-center items-center gap-8">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
-                </div>
-            </div>
-            <div class="border-t border-gray-200 mt-8 pt-6 text-center text-gray-600"><p>© <span id="year"></span> Kokomo Art Association. All Rights Reserved.</p></div>
-        </div>
-    </footer>
+    <div id="footer-placeholder"></div>
 
     <!-- Modal placeholder -->
     <div id="modal-placeholder"></div>
@@ -232,5 +180,7 @@
 
     });
     </script>
+<script src="app.js"></script>
+<script src="membership.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -67,8 +67,22 @@
     </header>
 
     <main>
-        <section>
-            <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/kaacolor.png" alt="Colorful watercolor background" class="w-full h-auto">
+        <section id="hero-carousel" class="relative">
+            <div class="overflow-hidden relative">
+                <div id="carousel-slides" class="flex transition-transform duration-700">
+                    <div class="min-w-full flex justify-center bg-white">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/kaacolor.png" alt="Colorful watercolor background" class="w-1/2 h-auto">
+                    </div>
+                    <div class="min-w-full flex items-center justify-center bg-gray-100">
+                        <h2 class="text-3xl md:text-5xl font-bold">Upcoming Events All Year</h2>
+                    </div>
+                    <div class="min-w-full flex items-center justify-center bg-teal-600 text-white">
+                        <h2 class="text-3xl md:text-5xl font-bold">Join Our Artist Community</h2>
+                    </div>
+                </div>
+            </div>
+            <button id="carousel-prev" class="absolute left-2 top-1/2 -translate-y-1/2 bg-white/70 p-2 rounded-full">&#8249;</button>
+            <button id="carousel-next" class="absolute right-2 top-1/2 -translate-y-1/2 bg-white/70 p-2 rounded-full">&#8250;</button>
         </section>
         <section class="bg-white py-16">
             <div class="container mx-auto px-6 text-center">
@@ -273,6 +287,25 @@
             '2025-3-15': [ { title: 'Junk Journal Workshop', time: '12:00 PM - 4:00 PM', description: 'Create a handmade journal from recycled and repurposed materials with talented artist Vivian Bennett.', cost: '$62.50 (all materials included)' } ],
             '2025-7-13': [ { title: 'Reception for Brandon C. Bass', time: '12:00 PM - 3:00 PM', description: 'Join us for a reception celebrating our July guest artist, Brandon C. Bass. Light refreshments will be served.', cost: 'Free to attend' } ]
         };
+        const generateCalendarLinks = (key, ev) => {
+            const [y,m,d] = key.split('-').map(Number);
+            const [startStr,endStr] = ev.time.split(' - ');
+            const parse = (s) => {
+                const [t,amp] = s.split(' ');
+                let [hh,mm] = t.split(':').map(Number);
+                if(amp==='PM' && hh<12) hh+=12;
+                if(amp==='AM' && hh===12) hh=0;
+                return {hh,mm};
+            };
+            const st = new Date(y, m-1, d, ...Object.values(parse(startStr)));
+            const en = new Date(y, m-1, d, ...Object.values(parse(endStr)));
+            const pad = x=>String(x).padStart(2,'0');
+            const fmt = (dt)=>`${dt.getFullYear()}${pad(dt.getMonth()+1)}${pad(dt.getDate())}T${pad(dt.getHours())}${pad(dt.getMinutes())}00`;
+            const gLink = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(ev.title)}&dates=${fmt(st)}/${fmt(en)}&details=${encodeURIComponent(ev.description)}`;
+            const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:${ev.title}\nDESCRIPTION:${ev.description}\nDTSTART:${fmt(st)}\nDTEND:${fmt(en)}\nEND:VEVENT\nEND:VCALENDAR`;
+            const icsLink = `data:text/calendar;charset=utf8,${encodeURIComponent(ics)}`;
+            return `<div class="mt-4 space-y-2"><a href="${gLink}" target="_blank" class="text-teal-600 hover:text-teal-800 font-semibold">Add to Google Calendar</a><br><a href="${icsLink}" download="event.ics" class="text-teal-600 hover:text-teal-800 font-semibold">Add to Outlook/Apple Calendar</a></div>`;
+        };
         let currentDate = new Date(2025, 6, 1);
         
         const modalPlaceholder = document.getElementById('modal-placeholder');
@@ -283,6 +316,17 @@
         const nextMonthBtn = document.getElementById('next-month-btn');
         const mobileMenuButton = document.getElementById('mobile-menu-button');
         const mobileMenu = document.getElementById('mobile-menu');
+        const slidesContainer = document.getElementById('carousel-slides');
+        let currentSlide = 0;
+        const showSlide = (i) => {
+            if(!slidesContainer) return;
+            const total = slidesContainer.children.length;
+            currentSlide = (i + total) % total;
+            slidesContainer.style.transform = `translateX(-${currentSlide * 100}%)`;
+        };
+        document.getElementById('carousel-prev')?.addEventListener('click', () => showSlide(currentSlide - 1));
+        document.getElementById('carousel-next')?.addEventListener('click', () => showSlide(currentSlide + 1));
+        setInterval(() => showSlide(currentSlide + 1), 5000);
 
         const createModal = (content) => {
             modalPlaceholder.innerHTML = `<div id="modal-overlay" class="modal-overlay"><div class="modal-container"><div class="p-8 relative"><button id="modal-close-btn" class="absolute top-4 right-4 text-gray-400 hover:text-gray-800 text-2xl z-10">&times;</button>${content}</div></div></div>`;
@@ -350,7 +394,8 @@
                     dayEl.appendChild(dot);
                     dayEl.addEventListener('click', () => {
                         const event = events[eventKey][0];
-                        const content = `<h2 class="text-2xl font-bold mb-2">${event.title}</h2><p class="text-gray-500 font-semibold mb-4">${event.time}</p><p class="text-gray-700 mb-4">${event.description}</p><p class="font-bold mb-6">${event.cost}</p><button class="event-form-trigger-modal w-full bg-teal-600 text-white py-2 px-4 rounded-md hover:bg-teal-700">Register Now</button>`;
+                        const links = generateCalendarLinks(eventKey, event);
+                        const content = `<h2 class="text-2xl font-bold mb-2">${event.title}</h2><p class="text-gray-500 font-semibold mb-4">${event.time}</p><p class="text-gray-700 mb-4">${event.description}</p><p class="font-bold mb-6">${event.cost}</p>${links}<button class="event-form-trigger-modal w-full bg-teal-600 text-white py-2 px-4 rounded-md hover:bg-teal-700 mt-4">Register Now</button>`;
                         createModal(content);
                     });
                 }
@@ -453,5 +498,6 @@
         renderCalendar();
     });
     </script>
+    <script src="membership.js"></script>
 </body>
 </html>

--- a/locations.html
+++ b/locations.html
@@ -57,41 +57,8 @@
     <div id="fb-root"></div>
     <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v18.0" nonce="aBcDeFg"></script>
 
-    <!-- Header and Navigation -->
-    <header class="bg-white shadow-md sticky top-0 z-50">
-        <nav class="container mx-auto px-6 py-3 flex justify-between items-center">
-            <div class="flex items-center">
-                <a href="index.html" class="flex items-center">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/918D5B2F-EEA0-4A9E-AC15-88359C704F97.png" alt="Kokomo Art Association Logo" class="h-12 w-auto" onerror="this.onerror=null;this.src='https://placehold.co/150x50/000000/FFFFFF?text=KAA+Logo';">
-                    <span class="hidden md:inline ml-4 text-black text-lg font-semibold">Kokomo Art Association</span>
-                </a>
-            </div>
-            <div class="hidden md:flex items-center space-x-6">
-                <a href="/index.html" class="text-gray-600 hover:text-teal-600 font-semibold">Home</a>
-                <a href="/about.html" class="text-gray-600 hover:text-teal-600 font-semibold">About</a>
-                <a href="/events.html" class="text-teal-600 font-semibold">Events</a>
-                <a href="/locations.html" class="text-gray-600 hover:text-teal-600 font-semibold">Locations</a>
-                 <a href="community_hub.html" class="text-gray-600 hover:text-teal-600 font-semibold">Community Hub</a>
-                <a href="get_involved.html" class="text-gray-600 hover:text-teal-600 font-semibold">Get Involved</a>
-                <a href="donate.html" class="text-gray-600 hover:text-teal-600 font-semibold">Donate</a>
-            </div>
-            <button id="mobile-menu-button" class="md:hidden flex items-center">
-                <i class="fas fa-bars text-gray-600 text-2xl"></i>
-            </button>
-        </nav>
-        <!-- Mobile Menu -->
-        <div id="mobile-menu" class="hidden md:hidden px-6 pb-4 bg-white border-t">
-             <a href="/index.html" class="block py-2 text-gray-600 hover:text-teal-600">Home</a>
-             <a href="/about.html" class="block py-2 text-gray-600 hover:text-teal-600">About</a>
-             <a href="/events.html" class="block py-2 text-teal-600">Events</a>
-             <a href="/locations.html" class="block py-2 text-gray-600 hover:text-teal-600">Locations</a>
-              <a href="community_hub.html" class="block py-2 text-gray-600 hover:text-teal-600">Community Hub</a>
-             <a href="get_involved.html" class="block py-2 text-gray-600 hover:text-teal-600">Get Involved</a>
-             <a href="donate.html" class="block py-2 text-gray-600 hover:text-teal-600">Donate</a>
-        </div>
-    </header>
-
-    <main>
+    <div id="header-placeholder"></div>
+<main>
          <!-- Hero Section - Placeholder or remove if not needed on subpages -->
         <section class="w-full bg-white flex justify-center py-8">
              <h1 class="text-4xl md:text-5xl font-bold leading-tight text-gray-800">Visit Our Locations</h1>
@@ -171,27 +138,7 @@
 
     </main>
 
-    <footer id="footer" class="bg-white text-gray-800 border-t">
-        <div class="container mx-auto px-6 py-12">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div class="md:col-span-2"><h4 class="font-bold text-lg mb-4 text-gray-900">About KAA</h4><p class="text-gray-600">The Kokomo Art Association was organized in 1926. Bylaws and a constitution were established in 1962, and not-for-profit status was attained in 1981. We are dedicated to promoting the arts and supporting local artists in our community.</p></div>
-                <div><h4 class="font-bold text-lg mb-4 text-gray-900">Join Our Newsletter</h4><form onsubmit="return false;"><div class="flex"><input type="email" class="w-full rounded-l-md px-3 py-2 border border-gray-300 text-gray-800" placeholder="your.email@example.com"><button type="submit" class="bg-teal-600 text-white px-4 py-2 rounded-r-md hover:bg-teal-700">→</button></div></form><div class="flex space-x-4 mt-4"><a href="https://www.facebook.com/KokomoArtAssociation/?fref=ts" target="_blank" rel="noopener noreferrer" aria-label="Facebook" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-facebook-square"></i></a><a href="https://www.instagram.com/kokomoartassociation/" target="_blank" rel="noopener noreferrer" aria-label="Instagram" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-instagram-square"></i></a></div></div>
-            </div>
-            <div class="border-t border-gray-200 mt-12 pt-8">
-                <h4 class="font-bold text-lg mb-6 text-center text-gray-700">Our Valued Sponsors</h4>
-                <div class="flex flex-wrap justify-center items-center gap-8">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
-                </div>
-            </div>
-            <div class="border-t border-gray-200 mt-8 pt-6 text-center text-gray-600"><p>© <span id="year"></span> Kokomo Art Association. All Rights Reserved.</p></div>
-        </div>
-    </footer>
+    <div id="footer-placeholder"></div>
 
     <!-- Modal placeholder -->
     <div id="modal-placeholder"></div>
@@ -357,5 +304,7 @@
         setInterval(updateSigns, 60000);
     });
     </script>
+<script src="app.js"></script>
+<script src="membership.js"></script>
 </body>
 </html>

--- a/membership.js
+++ b/membership.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const overlay = document.createElement('div');
+  overlay.id = 'membership-overlay';
+  overlay.className = 'fixed bottom-0 left-0 right-0 bg-teal-700 text-white text-sm px-4 py-2 flex flex-wrap items-center justify-between space-y-2 md:space-y-0 z-50';
+  overlay.innerHTML = `
+    <span id="member-info" class="mr-4">Not logged in</span>
+    <nav class="flex space-x-4 flex-wrap text-white underline">
+      <a href="https://studio-hub-eight.vercel.app/" target="_blank">Studio Hub</a>
+      <a href="https://studio-hub-eight.vercel.app/resources" target="_blank">Resources</a>
+      <a href="https://studio-hub-eight.vercel.app/events" target="_blank">Events</a>
+      <a href="https://studio-hub-eight.vercel.app/messages" target="_blank">Messages</a>
+      <a href="https://studio-hub-eight.vercel.app/bulletin" target="_blank">Bulletin</a>
+    </nav>
+    <button id="member-login-btn" class="bg-white text-teal-700 px-2 py-1 rounded">Login</button>
+  `;
+  document.body.appendChild(overlay);
+  const infoEl = document.getElementById('member-info');
+  const btn = document.getElementById('member-login-btn');
+  function update() {
+    const data = JSON.parse(localStorage.getItem('memberInfo') || '{}');
+    if (data.name) {
+      infoEl.textContent = `Logged in as ${data.name} (${data.id})`;
+      btn.textContent = 'Logout';
+    } else {
+      infoEl.textContent = 'Not logged in';
+      btn.textContent = 'Login';
+    }
+  }
+  btn.addEventListener('click', () => {
+    const data = JSON.parse(localStorage.getItem('memberInfo') || '{}');
+    if (data.name) {
+      localStorage.removeItem('memberInfo');
+      update();
+    } else {
+      const name = prompt('Enter your name');
+      if (!name) return;
+      const id = prompt('Enter membership ID');
+      if (!id) return;
+      localStorage.setItem('memberInfo', JSON.stringify({ name, id }));
+      update();
+    }
+  });
+  update();
+});


### PR DESCRIPTION
## Summary
- shrink hero banner into a carousel
- add simple carousel controls
- provide "Add to Calendar" links in event popups
- enforce single-line sponsor row on desktop
- load shared header/footer on dark and events pages
- add membership overlay taskbar with login and links
- unify header/footer on remaining pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875056f82208328af6dd244467688ef