### PR TITLE
Resize hero carousel image

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
             <div class="overflow-hidden relative">
                 <div id="carousel-slides" class="flex transition-transform duration-700">
                     <div class="min-w-full flex justify-center bg-white">
-                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/kaacolor.png" alt="Colorful watercolor background" class="w-1/2 h-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/kaacolor.png" alt="Colorful watercolor background" class="w-[38%] h-auto">
                     </div>
                     <div class="min-w-full flex items-center justify-center bg-gray-100">
                         <h2 class="text-3xl md:text-5xl font-bold">Upcoming Events All Year</h2>


### PR DESCRIPTION
## Summary
- shrink the hero carousel banner image width to make the banner about 25% smaller

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b4c3191c48328ae86f9faaf53d489