### PR TITLE
Update carousel size and remove login

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,22 +67,22 @@
     </header>
 
     <main>
-        <section id="hero-carousel" class="relative">
-            <div class="overflow-hidden relative">
+        <section id="hero-carousel" class="relative h-48 md:h-64 lg:h-80">
+            <div class="overflow-hidden relative h-full">
                 <div id="carousel-slides" class="flex transition-transform duration-700">
-                    <div class="min-w-full flex justify-center bg-white">
-                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/kaacolor.png" alt="Colorful watercolor background" class="w-1/2 h-auto">
+                    <div class="min-w-full h-full flex justify-center bg-white">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/kaacolor.png" alt="Colorful watercolor background" class="w-1/2 h-full object-contain">
                     </div>
-                    <div class="min-w-full flex items-center justify-center bg-gray-100">
-                        <h2 class="text-3xl md:text-5xl font-bold">Upcoming Events All Year</h2>
+                    <div class="min-w-full h-full flex items-center justify-center bg-gray-100">
+                        <h2 class="text-xl md:text-4xl font-bold">Upcoming Events All Year</h2>
                     </div>
-                    <div class="min-w-full flex items-center justify-center bg-teal-600 text-white">
-                        <h2 class="text-3xl md:text-5xl font-bold">Join Our Artist Community</h2>
+                    <div class="min-w-full h-full flex items-center justify-center bg-teal-600 text-white">
+                        <h2 class="text-xl md:text-4xl font-bold">Join Our Artist Community</h2>
                     </div>
                 </div>
             </div>
-            <button id="carousel-prev" class="absolute left-2 top-1/2 -translate-y-1/2 bg-white/70 p-2 rounded-full">&#8249;</button>
-            <button id="carousel-next" class="absolute right-2 top-1/2 -translate-y-1/2 bg-white/70 p-2 rounded-full">&#8250;</button>
+            <button id="carousel-prev" class="absolute left-2 bottom-2 translate-y-0 md:top-1/2 md:bottom-auto md:-translate-y-1/2 bg-white/70 p-2 rounded-full">&#8249;</button>
+            <button id="carousel-next" class="absolute right-2 bottom-2 translate-y-0 md:top-1/2 md:bottom-auto md:-translate-y-1/2 bg-white/70 p-2 rounded-full">&#8250;</button>
         </section>
         <section class="bg-white py-16">
             <div class="container mx-auto px-6 text-center">

--- a/membership.js
+++ b/membership.js
@@ -1,17 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
   const overlay = document.createElement('div');
   overlay.id = 'membership-overlay';
-  overlay.className = 'w-full bg-teal-700 text-white text-sm px-4 py-2 flex flex-wrap items-center justify-between space-y-2 md:space-y-0';
+  overlay.className = 'w-full bg-teal-700 text-white text-sm px-4 py-2 flex flex-wrap items-center justify-center md:justify-between space-y-2 md:space-y-0';
   overlay.innerHTML = `
-    <span id="member-info" class="mr-4">Not logged in</span>
     <nav class="flex items-center gap-4">
       <a href="https://studio-hub-eight.vercel.app/resources" target="_blank" title="Resources"><svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M204.3 5C104.9 24.4 24.8 104.3 5.2 203.4c-37 187 131.7 326.4 258.8 306.7 41.2-6.4 61.4-54.6 42.5-91.7-23.1-45.4 9.9-98.4 60.9-98.4h79.7c35.8 0 64.8-29.6 64.9-65.3C511.5 97.1 368.1-26.9 204.3 5zM96 320c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32zm32-128c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32zm128-64c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32zm128 64c-17.7 0-32-14.3-32-32s14.3-32 32-32 32 14.3 32 32-14.3 32-32 32z"></path></svg></a>
       <a href="https://studio-hub-eight.vercel.app/events" target="_blank" title="Events"><svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M0 464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V192H0v272zm320-196c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM192 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12h-40c-6.6 0-12-5.4-12-12v-40zM64 268c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zm0 128c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H76c-6.6 0-12-5.4-12-12v-40zM400 64h-48V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H160V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48H48C21.5 64 0 85.5 0 112v48h448v-48c0-26.5-21.5-48-48-48z"></path></svg></a>
       <a href="https://studio-hub-eight.vercel.app/messages" target="_blank" title="Messages"><svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 576 512" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M416 192c0-88.4-93.1-160-208-160S0 103.6 0 192c0 34.3 14.1 65.9 38 92-13.4 30.2-35.5 54.2-35.8 54.5-2.2 2.3-2.8 5.7-1.5 8.7S4.8 352 8 352c36.6 0 66.9-12.3 88.7-25 32.2 15.7 70.3 25 111.3 25 114.9 0 208-71.6 208-160zm122 220c23.9-26 38-57.7 38-92 0-66.9-53.5-124.2-129.3-148.1.9 6.6 1.3 13.3 1.3 20.1 0 105.9-107.7 192-240 192-10.8 0-21.3-.8-31.7-1.9C207.8 439.6 281.8 480 368 480c41 0 79.1-9.2 111.3-25 21.8 12.7 52.1 25 88.7 25 3.2 0 6.1-1.9 7.3-4.8 1.3-2.9.7-6.3-1.5-8.7-.3-.3-22.4-24.2-35.8-54.5z"></path></svg></a>
-      <a href="https://studio-hub-eight.vercel.app/bulletin" target="_blank" title="Bulletin Board"><svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 576 512" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M576 240c0-23.63-12.95-44.04-32-55.12V32.01C544 23.26 537.02 0 512 0c-7.12 0-14.19 2.38-19.98 7.02l-85.03 68.03C364.28 109.19 310.66 128 256 128H64c-35.35 0-64 28.65-64 64v96c0 35.35 28.65 64 64 64h33.7c-1.39 10.48-2.18 21.14-2.18 32 0 39.77 9.26 77.35 25.56 110.94 5.19 10.69 16.52 17.06 28.4 17.06h74.28c26.05 0 41.69-29.84 25.9-50.56-16.4-21.52-26.15-48.36-26.15-77.44 0-11.11 1.62-21.79 4.41-32H256c54.66 0 108.28 18.81 150.98 52.95l85.03 68.03a32.023 32.023 0 0 0 19.98 7.02c24.92 0 32-22.78 32-32V295.13C563.05 284.04 576 263.63 576 240zm-96 141.42l-33.05-26.44C392.95 311.78 325.12 288 256 288v-96c69.12 0 136.95-23.78 190.95-66.98L480 98.58v282.84z"></path></svg></a>
-      <a href="https://studio-hub-eight.vercel.app/login" target="_blank" title="Login"><svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"></path></svg></a>
+      <a href="https://studio-hub-eight.vercel.app/bulletin" target="_blank" title="Bulletin Board"><svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 576 512" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M576 240c0-23.63-12.95-44.04-32-55.12V32.01C544 23.26 537.02 0 512 0c-7.12 0-14.19 2.38-19.98 7.02l-85.03 68.03C364.28 109.19 310.66 128 256 128H64c-35.35 0-64 28.65-64 64v96c0 35.35 28.65 64 64 64h33.7c-1.39 10.48-2.18 21.14-2.18 32 0 39.77 9.26 77.35 25.56 110.94 5.19 10.69 16.52 17.06 28.4 17.06h74.28c26.05 0 41.69-29.84 25.9-50.56-16.4-21.52-26.15-48.36-26.15-77.44 0-11.11 1.62-21.79 4.41-32H256c54.66 0 108.28 18.81 150.98 52.95l85.03 68.03a32.023 32.023 0 0 0 19.98 7.02c24.92 0 32-22.78 32-32V295.13C563.05 284.04 576 263.63 576 240zM480 381.42l-33.05-26.44C392.95 311.78 325.12 288 256 288v-96c69.12 0 136.95-23.78 190.95-66.98L480 98.58v282.84z"></path></svg></a>
     </nav>
-    <button id="member-login-btn" class="bg-white text-teal-700 px-2 py-1 rounded">Login</button>
   `;
   const header = document.querySelector('header');
   if (header) {
@@ -19,31 +16,4 @@ document.addEventListener('DOMContentLoaded', () => {
   } else {
     document.body.prepend(overlay);
   }
-  const infoEl = document.getElementById('member-info');
-  const btn = document.getElementById('member-login-btn');
-  function update() {
-    const data = JSON.parse(localStorage.getItem('memberInfo') || '{}');
-    if (data.name) {
-      infoEl.textContent = `Logged in as ${data.name} (${data.id})`;
-      btn.textContent = 'Logout';
-    } else {
-      infoEl.textContent = 'Not logged in';
-      btn.textContent = 'Login';
-    }
-  }
-  btn.addEventListener('click', () => {
-    const data = JSON.parse(localStorage.getItem('memberInfo') || '{}');
-    if (data.name) {
-      localStorage.removeItem('memberInfo');
-      update();
-    } else {
-      const name = prompt('Enter your name');
-      if (!name) return;
-      const id = prompt('Enter membership ID');
-      if (!id) return;
-      localStorage.setItem('memberInfo', JSON.stringify({ name, id }));
-      update();
-    }
-  });
-  update();
 });


### PR DESCRIPTION
## Summary
- resize carousel for smaller height and center image
- move carousel controls to the bottom on mobile
- drop login button and overlay text from membership.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882b768a97883289b536b57133e0691